### PR TITLE
added support to replicate to local host without using ssh

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,6 +37,10 @@
 #+BEGIN_SRC sh
    # zap rep zap@bravo:rback/phe -r zroot/ROOT zroot/usr/home/jrm
 #+END_SRC
+   Replicate datasets (recursively for zroot/ROOT) to the localhost, under the =rback/phe= dataset, but this time specify the datasets on the command line. SSH will not be used in this case
+#+BEGIN_SRC sh
+   # zap rep localhost:rback/phe -r zroot/ROOT zroot/usr/home/jrm
+#+END_SRC
    Destroy expired snapshots.  Be verbose.
 #+BEGIN_SRC sh
    # zap destroy -v
@@ -112,6 +116,7 @@ and =rep= subcommands.
    - Joseph Mingrone <jrm@ftfl.ca>
    - Tobias Kortkamp <t@tobik.me>
    - David Samms <dsamms@nw-ds.com>
+   - Victor Naumov <vicnaumov@gmail.com>
 ** License
    zap is released under a BSD 2-Clause License.  Refer to the header of each
    source file for details.

--- a/zap
+++ b/zap
@@ -282,28 +282,28 @@ argument." ;;
 
 # execute on the "target" machine
 target_exec() {
-  local sshto=$1
-  local tcmd=$2
-  case "$sshto" in
+  _sshto=$1
+  _tcmd=$2
+  case "$_sshto" in
     "localhost"|"127.0.0.1"|"::1")
-      eval ${tcmd}
+      eval "${_tcmd}"
       ;;
     *)
       # interpret remote command with sh to avoid surprises with remote shell
-      ssh "$sshto" "sh -c '${tcmd}'"
+      ssh "$_sshto" "sh -c '${_tcmd}'"
       ;;
   esac
 }
 
 target_echo() {
-  local sshto=$1
-  local tcmd=$2
-  case "$sshto" in
+  _sshto=$1
+  _tcmd=$2
+  case "$_sshto" in
     "localhost"|"127.0.0.1"|"::1")
-      [ -n "$v_opt" ] && echo ${tcmd}
+      [ -n "$v_opt" ] && echo "${_tcmd}"
       ;;
     *)
-      [ -n "$v_opt" ] && echo "ssh \"$sshto\" \"sh -c '${tcmd}'\""
+      [ -n "$v_opt" ] && echo "ssh \"$_sshto\" \"sh -c '${_tcmd}'\""
       ;;
   esac
 }
@@ -356,7 +356,7 @@ a resilver in progress."
       [ -n "$v_opt" ] && \
         echo "No remote snapshots found. Sending full stream."
       tcmd="zfs recv -Fu $v_opt -d $rloc"
-      [ -n "$v_opt" ] && echo -n "zfs send -p $lsnap | " && target_echo "$sshto" "$tcmd"
+      [ -n "$v_opt" ] && printf "zfs send -p %s | " "$lsnap" && target_echo "$sshto" "$tcmd"
       if zfs send -p "$lsnap" | target_exec "$sshto" "$tcmd"
       then
         [ -n "$v_opt" ] && \
@@ -404,7 +404,7 @@ ${rloc}${fs}${rsnap}."
           # interpret remote command with sh to avoid surprises with
           # remote shell
           tcmd="zfs recv -du $F_opt $v_opt $rloc"
-	  [ -n "$v_opt" ] && echo -n "zfs send $i $sp $lsnap | " && target_echo "$sshto" "$tcmd"
+	  [ -n "$v_opt" ] && printf "zfs send %s %s %s | " "$i" "$sp" "$lsnap" && target_echo "$sshto" "$tcmd"
 
           if zfs send $i "$sp" "$lsnap" | target_exec "$sshto" "$tcmd"
           then

--- a/zap.1
+++ b/zap.1
@@ -166,6 +166,13 @@ line. If you use a non-default ssh port, specify it in ~/.ssh/config.
 zap rep zap@bravo:rback/phe -r zroot/ROOT zroot/usr/home/jrm
 .Ed
 .Pp
+Replicate datasets (recursively for zroot/ROOT) to localhost, under
+the rback/phe dataset, but this time specify the datasets on the command
+line. Ssh will not be used in this case.
+.Bd -literal -offset indent
+zap rep localhost:rback/phe -r zroot/ROOT zroot/usr/home/jrm
+.Ed
+.Pp
 Destroy expired snapshots.  Be verbose.
 .Bd -literal -offset indent
 zap destroy -v
@@ -207,6 +214,7 @@ disks, so only do it every 24 hours.
 .It An Joseph Mingrone Mt jrm@ftfl.ca
 .It An Tobias Kortkamp Mt t@tobik.me
 .It An David Samms Mt dsamms@nw-ds.com
+.It An Victor Naumov Mt vicnaumov@gmail.com
 .El
 .Sh BUGS
 .Lk http://github.com/jehops/zap/issues Issue tracker


### PR DESCRIPTION
Hi Joseph,

Thank you for your excellent zap tool. It is almost exactly what I need to make backups using zfs send/receive. Moreover FreeBSD has zap package!

In my case I have an offline backup disk connected to the same machine. It also could be SATA or USB drive. I want to backup locally and my patch enables it. If a hostname is "localhost" then it does "zfs send ... | zfs receive" directly without involving ssh.

cheers
victor