### PR TITLE
Feature: zfs prefix

### DIFF
--- a/README.org
+++ b/README.org
@@ -13,7 +13,9 @@
    =# zap -v | -version | --version=
 
 ** Examples
-   Create snapshots that will expire after 3 weeks.  The =#= prompt indicates commands that are run as root.  A solution that delegates permissions for most of these commands to an unprivileged user is described [[http://ftfl.ca/blog/2016-12-27-zfs-replication.html][here]].
+   For the below examples, the =#= prompt indicates commands that are run as root.  A solution that delegates permissions for most of these commands to an unprivileged user on FreeBSD is described [[http://ftfl.ca/blog/2016-12-27-zfs-replication.html][here]]; a similar apprpach can be used for Solaris (OpenSolaris, OpenIndiana, illumos) hosts.  Linux users are advised to set the =ZAP_PREFIX= environment variable to =sudo= and allow the running user to run =zfs= and =zpool= commands.
+
+   Create snapshots that will expire after 3 weeks.
 #+BEGIN_SRC sh
   # zfs set zap:snap=on zroot/usr/home/nox zroot/var/
   # zfs set zap:snap=off zroot/var/crash zroot/var/tmp zroot/var/mail
@@ -112,6 +114,15 @@ and =rep= subcommands.
     =-r=  Recursively create or replicate snapshots of all descendants.
 
     =-v=  Be verbose.
+
+** Environment variables
+   =ZAP_PREFIX=
+
+   Prefix all =zfs= commands with the contents of the variable. This is intended to allow privilege escalation with sudo or similar tools, which is a requirement on Linux if you do not want to run zap as root until pool-level access permissions are implemented in OpenZFS.
+
+   =ZAP_PREFIX_REMOTE=
+
+   Same as =ZAP_PREFIX= but used on the remote host over SSH when replicating.
 
 ** Author and Contributors
    - Joseph Mingrone <jrm@ftfl.ca>

--- a/zap
+++ b/zap
@@ -65,7 +65,7 @@ pool_ok () {
   done
   shift $(( OPTIND - 1 ))
 
-  if zpool status "$1" | grep -Eq "$skip"; then
+  if $ZAP_PREFIX zpool status "$1" | grep -Eq "$skip"; then
     return 1
   fi
   return 0
@@ -73,7 +73,7 @@ pool_ok () {
 
 # pool_scrub <pool>
 pool_scrub () {
-  if zpool status "$1" | grep -q "scrub in progress"; then
+  if $ZAP_PREFIX zpool status "$1" | grep -q "scrub in progress"; then
     return 0
   fi
   return 1
@@ -81,7 +81,7 @@ pool_scrub () {
 
 # pool_resilver <pool>
 pool_resilver () {
-  if zpool status "$1" | grep -q "scan: resilver in progress"; then
+  if $ZAP_PREFIX zpool status "$1" | grep -q "scan: resilver in progress"; then
     return 0
   fi
   return 1

--- a/zap.1
+++ b/zap.1
@@ -231,6 +231,24 @@ disks, so only do it every 24 hours.
 # replicate datasets
 54	*/1	*	*	*	zap rep -v
 .Ed
+.Sh ENVIRONMENT VARIABLES
+.Bl -tag -width "ZAP_PREFIX_REMOTE"
+.It Ev ZAP_PREFIX
+Prefix all
+.Ar zfs
+commands with the contents of the variable. This is intended to allow privilege
+escalation with
+.Ar sudo
+or similar tools, which is a requirement on Linux if you do not want to run
+.Nm
+as root until pool-level access permissions are implemented in OpenZFS.
+.It Ev ZAP_PREFIX_REMOTE
+Prefix all remote
+.Ar zfs
+commands over
+.Ar ssh
+with the contents of the variable.
+.El
 .Sh SEE ALSO
 .Bl -tag -compact -width "12345678"
 .It Lk http://github.com/jehops/zap GitHub Page


### PR DESCRIPTION
New environment variables `ZAP_PREFIX` and `ZAP_PREFIX_REMOTE` will allow `zfs` and `zpool` to be prefixed on the local and remote machine, respectively. This is a requirement for my use-case which is on Linux as an unprivileged user—ZFS access control is a no-op on OpenZFS so using `sudo` or similar is required.