### PR TITLE
fix regression introduced in ff84643d

### DIFF
--- a/zap
+++ b/zap
@@ -386,7 +386,7 @@ rep_full() {
     else warn "Failed to replicate $lsnap to $sshto:$rloc"
     fi
   else # replicating remotely
-    if rsend "-Lep $C_opt $lsnap" "zfs recv -Fu $v_opt -d $rloc'"; then
+    if rsend "-Lep $C_opt $lsnap" "zfs recv -Fu $v_opt -d $rloc"; then
       [ -n "$v_opt" ] && \
         echo "zfs bookmark $lsnap $(echo "$lsnap" | sed 's/@/#/')"
       zfs bookmark "$lsnap" "$(echo "$lsnap" | sed 's/@/#/')"


### PR DESCRIPTION
It looks like when translating the `ssh` commands into `rsend` to implement `ZAP-FILTER`, a single quote at the end of one of the statements did not get removed. Replicating no longer works due to this.
```diff
diff --git a/zap b/zap
index 898f6bb..e898901 100755
--- a/zap
+++ b/zap
@@ -352,11 +352,12 @@ rep_full() {
     else warn "Failed to replicate $lsnap to $sshto:$rloc"
     fi
   else # replicating remotely
-    [ -n "$v_opt" ] && \
-      echo "zfs send -Lep $C_opt $lsnap | ssh $sshto \"sh -c 'zfs recv -Fu \
-$v_opt -d $rloc'\""
-    if zfs send -Lep $C_opt "$lsnap" | \
-        ssh "$sshto" "sh -c 'zfs recv -Fu $v_opt -d $rloc'"; then
+    if [ -n "$v_opt" ]; then
+      echo -n "zfs send -Lep $C_opt $lsnap "
+      if [ -n "$ZAP_FILTER" ]; then echo "| $ZAP_FILTER "; fi
+      echo "| ssh $sshto \"sh -c 'zfs recv -Fu $v_opt -d $rloc'\""
+    fi
+    if rsend "-Lep $C_opt $lsnap" "zfs recv -Fu $v_opt -d $rloc'"; then
       [ -n "$v_opt" ] && \
         echo "zfs bookmark $lsnap $(echo "$lsnap" | sed 's/@/#/')"
       zfs bookmark "$lsnap" "$(echo "$lsnap" | sed 's/@/#/')"
```
```
if rsend "-Lep $C_opt $lsnap" "zfs recv -Fu $v_opt -d $rloc'"; then
                                                           ^
```