### PR TITLE
Add raw flag when replicating encrypted datasets

### DIFF
--- a/zap
+++ b/zap
@@ -497,7 +497,7 @@ a resilver in progress."
 creation ${rloc}${fs} 2>/dev/null | head -n1'" | sed 's/^.*@/@/')
     fi
     # add raw (-w) flag for encrypted datasets
-    if [ "$(zfs get -H -o value encryption "$1")" != off ]; then
+    if [ "$(zfs get -H -o value encryption "$1" 2>/dev/null)" != off ]; then
       raw='-w'
     else
       raw=''


### PR DESCRIPTION
Adds `-w` to `zfs send` when the dataset is encrypted. This is required to send encrypted datasets without having the key loaded and to keep that key set on the receiving side.
I do not see a reason to prevent the flag from being added, so I did not add an argument to `zap` to do so—having an encrypted dataset and then sending it unencrypted after they key was loaded sounds pretty weird. It is possible to do but I don't know why anyone would want to.

I still prefer `zap` for its simplicity over more robust solutions... With this PR, I can finally use `zap` in production on Linux 🎉